### PR TITLE
feat: allow usage with other express middlewares

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ function Multer (options) {
   this.limits = options.limits
   this.preservePath = options.preservePath
   this.fileFilter = options.fileFilter || allowAll
+  this.expressMiddleware = options.expressMiddleware || []
 }
 
 Multer.prototype._makeMiddleware = function (fields, fileStrategy) {
@@ -49,7 +50,8 @@ Multer.prototype._makeMiddleware = function (fields, fileStrategy) {
       preservePath: this.preservePath,
       storage: this.storage,
       fileFilter: wrappedFileFilter,
-      fileStrategy: fileStrategy
+      fileStrategy: fileStrategy,
+      expressMiddleware: this.expressMiddleware,
     }
   }
 

--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -24,6 +24,7 @@ function makeMiddleware (setup) {
     var fileFilter = options.fileFilter
     var fileStrategy = options.fileStrategy
     var preservePath = options.preservePath
+    var expressMiddleware = options.expressMiddleware
 
     req.body = Object.create(null)
 
@@ -41,6 +42,7 @@ function makeMiddleware (setup) {
     var errorOccured = false
     var pendingWrites = new Counter()
     var uploadedFiles = []
+    var middlewareError;
 
     function done (err) {
       if (isDone) return
@@ -53,8 +55,8 @@ function makeMiddleware (setup) {
       onFinished(req, function () { next(err) })
     }
 
-    function indicateDone () {
-      if (readFinished && pendingWrites.isZero() && !errorOccured) done()
+    function indicateDone (err) {
+      if (readFinished && pendingWrites.isZero() && !errorOccured) done(err)
     }
 
     function abortWithError (uploadError) {
@@ -94,7 +96,18 @@ function makeMiddleware (setup) {
     })
 
     // handle files
-    busboy.on('file', function (fieldname, fileStream, filename, encoding, mimetype) {
+    busboy.on('file', async function (fieldname, fileStream, filename, encoding, mimetype) {    
+      // process any necessary express middleware before streaming file
+      for await (const middleware of expressMiddleware){
+        try{
+          await middleware(req)
+        }catch(err){
+          middlewareError = err;
+          // discard file
+          return fileStream.resume()
+        }
+      }
+        
       // don't attach to the files object, if there is no file
       if (!filename) return fileStream.resume()
 
@@ -171,7 +184,7 @@ function makeMiddleware (setup) {
     busboy.on('fieldsLimit', function () { abortWithCode('LIMIT_FIELD_COUNT') })
     busboy.on('finish', function () {
       readFinished = true
-      indicateDone()
+      indicateDone(middlewareError)
     })
 
     req.pipe(busboy)


### PR DESCRIPTION
The Changes are to allow the developer use the multer middleware  alongside other express middlewares that require access to the request body before multer uploads/streams the incoming file